### PR TITLE
修复endpoint scheme与配置不一致的问题

### DIFF
--- a/tools/get_file_by_url.py
+++ b/tools/get_file_by_url.py
@@ -136,7 +136,7 @@ class GetFileByUrlTool(Tool):
             parts = parsed_url.hostname.split('.', 1)
             if len(parts) == 2:
                 bucket_name = parts[0]
-                endpoint = parts[1]
+                endpoint =  f"{parsed_url.scheme}://{parts[1]}"
                 return (bucket_name, endpoint, object_key)
         
         # 对于自定义域名格式，需要额外的endpoint或bucket验证


### PR DESCRIPTION
使用tool get_file_by_url时发现配置正确，但是出现了403错误。排查发现传入url的endpoint https被改成了http. 在此处加上scheme就可以了